### PR TITLE
Feature: /time-now endpoint

### DIFF
--- a/src/pages/api/reverse-geocode.ts
+++ b/src/pages/api/reverse-geocode.ts
@@ -15,7 +15,7 @@ const reverseGeocodeHandler: APIRequestHandler = async (request, response) => {
 
   const locationResponse = await reverseGeocode({ latitude, longitude });
 
-  return response.json(locationResponse);
+  return response.status(200).json(locationResponse);
 };
 
 export default reverseGeocodeHandler;

--- a/src/pages/api/time-now.ts
+++ b/src/pages/api/time-now.ts
@@ -3,7 +3,7 @@ import { APIRequestHandler } from 'typings';
 const timeNowHandler: APIRequestHandler = async (_, response) => {
   const currentISOTimeString = new Date().toISOString();
 
-  return response.json({ time: currentISOTimeString });
+  return response.status(200).json({ time: currentISOTimeString });
 };
 
 export default timeNowHandler;


### PR DESCRIPTION
### Summary:
- Created the endpoint `/api/time-now`, meant to provide an accurate, up-to-date UTC time at the moment of the request;